### PR TITLE
use localhost instead of 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ OR... use vs code & the config recommended in the jest docs.
 
 Start the create-react-app server with `HTTPS=true yarn start` and the cra proxy will forward requests to the prod server.
 
-Log in with your account at `https://127.0.0.1:3000/user` -- you will get redirected after logging in but just flip back to `https://127.0.0.1/user` to verify that you are logged in. Add some PDFs for yourself as documented [in our prototype doc](https://docs.google.com/document/d/1n5cPukP2cEdlmCV9YqwgpYyOITPaiuxjiir-rX7P4ec/edit#heading=h.44ejuwli3tac)
+Log in with your account at `https://localhost:3000/user` -- you will get redirected after logging in but just flip back to `https://localhost/user` to verify that you are logged in. Add some PDFs for yourself as documented [in our prototype doc](https://docs.google.com/document/d/1n5cPukP2cEdlmCV9YqwgpYyOITPaiuxjiir-rX7P4ec/edit#heading=h.44ejuwli3tac)
 
-Now, navigate to `https://127.0.0.1:3000` and the react app should load up just fine.
+Now, navigate to `https://localhost:3000` and the react app should load up just fine.
 
 ## Run tests
 

--- a/src/api.js
+++ b/src/api.js
@@ -1,8 +1,7 @@
 import fetch from 'isomorphic-fetch';
 
 //export const API_HOST = 'https://data.detroitledger.org';
-//export const API_HOST = 'http://127.0.0.1:8888';
-export const API_HOST = 'https://127.0.0.1:3000';
+export const API_HOST = 'https://localhost:3000';
 
 /**
  *  Mutate an array of responses into an object keyed by their IDs.


### PR DESCRIPTION
create-react-app server uses localhost, but we were using the IP
which causes perplexing cross-origin errors

just use localhost everywhere