### PR TITLE
use .env for api host setting

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+REACT_APP_API_HOST=https://localhost:3000
+

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,2 @@
+REACT_APP_API_HOST=https://data.detroitledger.org
+

--- a/src/api.js
+++ b/src/api.js
@@ -2,8 +2,7 @@ import fetch from 'isomorphic-fetch';
 
 import LedgerApi from './LedgerApi';
 
-export const API_HOST = 'https://data.detroitledger.org';
-//export const API_HOST = 'https://localhost:3000';
+export const API_HOST = process.env.REACT_APP_API_HOST || 'https://data.detroitledger.org';
 
 /**
  *  Mutate an array of responses into an object keyed by their IDs.


### PR DESCRIPTION
fixes #47 

provide default configs:
use CRA proxy for dev, data.detroitledger.org for prod